### PR TITLE
AbstractRectangle.contains fix.

### DIFF
--- a/src/main/java/pythagoras/f/AbstractRectangle.java
+++ b/src/main/java/pythagoras/f/AbstractRectangle.java
@@ -108,7 +108,7 @@ public abstract class AbstractRectangle extends RectangularShape implements IRec
 
         px -= x;
         py -= y;
-        return px < width() && py < height();
+        return px <= width() && py <= height();
     }
 
     @Override // from interface IShape


### PR DESCRIPTION
Points on the top and left edges are considered contained, so should
points on right and bottom.  This also makes contains() consistent with
outcode().

Maybe IShape.contains should document how points on edges are handled?
AbstractCircle.contains is another one that doesn't consider edge points
contained.
